### PR TITLE
Update Paimon.moe import OpenReadStream to allow file sizes up to 5MB

### DIFF
--- a/AkashaScanner/Ui/Pages/Exports/PaimonMoeExports.razor
+++ b/AkashaScanner/Ui/Pages/Exports/PaimonMoeExports.razor
@@ -67,7 +67,7 @@
                 var value = await JS.InvokeAsync<string>("__akasha_getInputValue", fileInputId);
                 if (!string.IsNullOrEmpty(value))
                 {
-                    using var stream = import.OpenReadStream();
+                    using var stream = import.OpenReadStream(maxAllowedSize: 1024 * 1024 * 5);
                     using var reader = new System.IO.StreamReader(stream, System.Text.Encoding.UTF8);
                     importContent = await reader.ReadToEndAsync();
                 }


### PR DESCRIPTION
The choice of 5MB is completely arbitrary, but I figured it should be large enough to futureproof exports for the foreseeable future. I have not and am not able to build this project myself, so I'd like to suggest you test and build this yourself before accepting and releasing.
Solves #20 